### PR TITLE
Fix a call by reference warning

### DIFF
--- a/lib/git.class.php
+++ b/lib/git.class.php
@@ -222,8 +222,8 @@ class Git
     {
         $pos = 0;
 
-        $base_size = Binary::git_varint($delta, &$pos);
-        $result_size = Binary::git_varint($delta, &$pos);
+        $base_size = Binary::git_varint($delta, $pos);
+        $result_size = Binary::git_varint($delta, $pos);
 
         $r = '';
         while ($pos < strlen($delta))


### PR DESCRIPTION
This fix will let it work with the php setting

allow_call_time_pass_reference = Off
